### PR TITLE
Reimplement CSymbolResolver with preload worker

### DIFF
--- a/src/WinDepends/Forms/ConfigurationForm.Designer.cs
+++ b/src/WinDepends/Forms/ConfigurationForm.Designer.cs
@@ -28,17 +28,17 @@
         /// </summary>
         private void InitializeComponent()
         {
-            TreeNode treeNode1 = new TreeNode("History");
-            TreeNode treeNode2 = new TreeNode("Main", new TreeNode[] { treeNode1 });
-            TreeNode treeNode3 = new TreeNode("Analysis (global)");
-            TreeNode treeNode4 = new TreeNode("ApiSets");
-            TreeNode treeNode5 = new TreeNode("External Function Help");
-            TreeNode treeNode6 = new TreeNode("External Module Viewer");
-            TreeNode treeNode7 = new TreeNode("Handled File Extensions");
-            TreeNode treeNode8 = new TreeNode("Module Search Order");
-            TreeNode treeNode9 = new TreeNode("Module Search Order (drivers)");
-            TreeNode treeNode10 = new TreeNode("Server");
-            TreeNode treeNode11 = new TreeNode("Symbols");
+            TreeNode treeNode12 = new TreeNode("History");
+            TreeNode treeNode13 = new TreeNode("Main", new TreeNode[] { treeNode12 });
+            TreeNode treeNode14 = new TreeNode("Analysis (global)");
+            TreeNode treeNode15 = new TreeNode("ApiSets");
+            TreeNode treeNode16 = new TreeNode("External Function Help");
+            TreeNode treeNode17 = new TreeNode("External Module Viewer");
+            TreeNode treeNode18 = new TreeNode("Handled File Extensions");
+            TreeNode treeNode19 = new TreeNode("Module Search Order");
+            TreeNode treeNode20 = new TreeNode("Module Search Order (drivers)");
+            TreeNode treeNode21 = new TreeNode("Server");
+            TreeNode treeNode22 = new TreeNode("Symbols");
             splitContainer2 = new SplitContainer();
             splitContainer1 = new SplitContainer();
             TVSettings = new TreeView();
@@ -161,6 +161,7 @@
             browseFileDialog = new OpenFileDialog();
             folderBrowserDialog = new FolderBrowserDialog();
             colorDialog = new ColorDialog();
+            buttonBrowseCache = new Button();
             ((System.ComponentModel.ISupportInitialize)splitContainer2).BeginInit();
             splitContainer2.Panel1.SuspendLayout();
             splitContainer2.Panel2.SuspendLayout();
@@ -246,40 +247,40 @@
             TVSettings.HideSelection = false;
             TVSettings.Location = new Point(0, 0);
             TVSettings.Name = "TVSettings";
-            treeNode1.Name = "HistoryNode";
-            treeNode1.Tag = "11";
-            treeNode1.Text = "History";
-            treeNode2.Name = "MainWindowNode";
-            treeNode2.Tag = "10";
-            treeNode2.Text = "Main";
-            treeNode3.Name = "AnalysisNode";
-            treeNode3.Tag = "20";
-            treeNode3.Text = "Analysis (global)";
-            treeNode4.Name = "ApiSetsNode";
-            treeNode4.Tag = "30";
-            treeNode4.Text = "ApiSets";
-            treeNode5.Name = "ExternalFunctionHelpNode";
-            treeNode5.Tag = "40";
-            treeNode5.Text = "External Function Help";
-            treeNode6.Name = "ExternalModuleViewerNode";
-            treeNode6.Tag = "50";
-            treeNode6.Text = "External Module Viewer";
-            treeNode7.Name = "ShellIntegrationNode";
-            treeNode7.Tag = "60";
-            treeNode7.Text = "Handled File Extensions";
-            treeNode8.Name = "SearchOrderNode";
-            treeNode8.Tag = "70";
-            treeNode8.Text = "Module Search Order";
-            treeNode9.Name = "SearchOrderDriverNode";
-            treeNode9.Tag = "80";
-            treeNode9.Text = "Module Search Order (drivers)";
-            treeNode10.Name = "ServerNode";
-            treeNode10.Tag = "90";
-            treeNode10.Text = "Server";
-            treeNode11.Name = "SymbolsNode";
-            treeNode11.Tag = "100";
-            treeNode11.Text = "Symbols";
-            TVSettings.Nodes.AddRange(new TreeNode[] { treeNode2, treeNode3, treeNode4, treeNode5, treeNode6, treeNode7, treeNode8, treeNode9, treeNode10, treeNode11 });
+            treeNode12.Name = "HistoryNode";
+            treeNode12.Tag = "11";
+            treeNode12.Text = "History";
+            treeNode13.Name = "MainWindowNode";
+            treeNode13.Tag = "10";
+            treeNode13.Text = "Main";
+            treeNode14.Name = "AnalysisNode";
+            treeNode14.Tag = "20";
+            treeNode14.Text = "Analysis (global)";
+            treeNode15.Name = "ApiSetsNode";
+            treeNode15.Tag = "30";
+            treeNode15.Text = "ApiSets";
+            treeNode16.Name = "ExternalFunctionHelpNode";
+            treeNode16.Tag = "40";
+            treeNode16.Text = "External Function Help";
+            treeNode17.Name = "ExternalModuleViewerNode";
+            treeNode17.Tag = "50";
+            treeNode17.Text = "External Module Viewer";
+            treeNode18.Name = "ShellIntegrationNode";
+            treeNode18.Tag = "60";
+            treeNode18.Text = "Handled File Extensions";
+            treeNode19.Name = "SearchOrderNode";
+            treeNode19.Tag = "70";
+            treeNode19.Text = "Module Search Order";
+            treeNode20.Name = "SearchOrderDriverNode";
+            treeNode20.Tag = "80";
+            treeNode20.Text = "Module Search Order (drivers)";
+            treeNode21.Name = "ServerNode";
+            treeNode21.Tag = "90";
+            treeNode21.Text = "Server";
+            treeNode22.Name = "SymbolsNode";
+            treeNode22.Tag = "100";
+            treeNode22.Text = "Symbols";
+            TVSettings.Nodes.AddRange(new TreeNode[] { treeNode13, treeNode14, treeNode15, treeNode16, treeNode17, treeNode18, treeNode19, treeNode20, treeNode21, treeNode22 });
             TVSettings.Size = new Size(210, 444);
             TVSettings.TabIndex = 0;
             TVSettings.AfterSelect += TVSettings_AfterSelect;
@@ -1419,6 +1420,7 @@
             // 
             // groupBoxSymbols
             // 
+            groupBoxSymbols.Controls.Add(buttonBrowseCache);
             groupBoxSymbols.Controls.Add(buttonSymbolsDefault);
             groupBoxSymbols.Controls.Add(buttonSymbolPickColor);
             groupBoxSymbols.Controls.Add(panelSymColor);
@@ -1430,14 +1432,14 @@
             groupBoxSymbols.Controls.Add(label18);
             groupBoxSymbols.Location = new Point(6, 50);
             groupBoxSymbols.Name = "groupBoxSymbols";
-            groupBoxSymbols.Size = new Size(487, 208);
+            groupBoxSymbols.Size = new Size(487, 255);
             groupBoxSymbols.TabIndex = 0;
             groupBoxSymbols.TabStop = false;
             // 
             // buttonSymbolsDefault
             // 
             buttonSymbolsDefault.AutoSize = true;
-            buttonSymbolsDefault.Location = new Point(348, 155);
+            buttonSymbolsDefault.Location = new Point(348, 197);
             buttonSymbolsDefault.Name = "buttonSymbolsDefault";
             buttonSymbolsDefault.Size = new Size(94, 25);
             buttonSymbolsDefault.TabIndex = 9;
@@ -1448,7 +1450,7 @@
             // buttonSymbolPickColor
             // 
             buttonSymbolPickColor.AutoSize = true;
-            buttonSymbolPickColor.Location = new Point(267, 155);
+            buttonSymbolPickColor.Location = new Point(267, 197);
             buttonSymbolPickColor.Name = "buttonSymbolPickColor";
             buttonSymbolPickColor.Size = new Size(75, 25);
             buttonSymbolPickColor.TabIndex = 8;
@@ -1459,7 +1461,7 @@
             // panelSymColor
             // 
             panelSymColor.Controls.Add(label11);
-            panelSymColor.Location = new Point(19, 152);
+            panelSymColor.Location = new Point(19, 194);
             panelSymColor.Name = "panelSymColor";
             panelSymColor.Size = new Size(242, 30);
             panelSymColor.TabIndex = 7;
@@ -1559,6 +1561,17 @@
             // 
             folderBrowserDialog.AddToRecent = false;
             folderBrowserDialog.ShowHiddenFiles = true;
+            // 
+            // buttonBrowseCache
+            // 
+            buttonBrowseCache.AutoSize = true;
+            buttonBrowseCache.Location = new Point(19, 152);
+            buttonBrowseCache.Name = "buttonBrowseCache";
+            buttonBrowseCache.Size = new Size(122, 25);
+            buttonBrowseCache.TabIndex = 10;
+            buttonBrowseCache.Text = "Browse Cache";
+            buttonBrowseCache.UseVisualStyleBackColor = true;
+            buttonBrowseCache.Click += buttonBrowseCache_Click;
             // 
             // ConfigurationForm
             // 
@@ -1766,5 +1779,6 @@
         private CheckBox chBoxCustomImageBase;
         private CheckBox chBoxAnalysisEnableExperimentalFeatures;
         private CheckBox chBoxExpandForwarders;
+        private Button buttonBrowseCache;
     }
 }

--- a/src/WinDepends/Forms/ConfigurationForm.cs
+++ b/src/WinDepends/Forms/ConfigurationForm.cs
@@ -6,7 +6,7 @@
 *
 *  VERSION:     1.00
 *
-*  DATE:        26 Apr 2026
+*  DATE:        28 May 2026
 *
 * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
 * ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED
@@ -1058,6 +1058,59 @@ public partial class ConfigurationForm : Form
             CConsts.AvailableGuiFontSizes.Contains(selectedSize))
         {
             _config.GuiFontSize = selectedSize;
+        }
+    }
+
+    public static bool TryExtractSymbolsCachePath(string symbolsPath, out string cachePath)
+    {
+        string[] parts;
+
+        cachePath = null;
+
+        if (string.IsNullOrWhiteSpace(symbolsPath))
+            return false;
+
+        parts = symbolsPath.Split('*', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length < 2)
+            return false;
+
+        if (!string.Equals(parts[0], "srv", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(parts[0], "cache", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (parts[1].StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            parts[1].StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        cachePath = parts[1];
+        return !string.IsNullOrWhiteSpace(cachePath);
+    }
+
+    private void buttonBrowseCache_Click(object sender, EventArgs e)
+    {
+        if (TryExtractSymbolsCachePath(symbolsStoreTextBox.Text, out string cachePath))
+        {
+            if (Directory.Exists(cachePath))
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo()
+                    {
+                        FileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), CConsts.ExplorerApp),
+                        Arguments = cachePath,
+                        Verb = "open",
+                        UseShellExecute = true
+                    });
+                }
+                catch
+                {
+                    //Intentionally silent.
+                }
+            }
         }
     }
 }

--- a/src/WinDepends/MainForm/MainForm.Functions.cs
+++ b/src/WinDepends/MainForm/MainForm.Functions.cs
@@ -131,14 +131,16 @@ public partial class MainForm
         }
     }
 
-    static string TryUndecorateFunction(bool viewUndecorated, CFunction function)
+    static string TryUndecorateFunction(CSymbolResolver symbolResolver, bool viewUndecorated, CFunction function)
     {
-        if (!CSymbolResolver.UndecorationReady)
+        if (!symbolResolver.UndecorationReady)
         {
             return function.RawName;
         }
 
-        return viewUndecorated && function.IsNameDecorated() ? function.UndecorateFunctionName() : function.RawName;
+        return viewUndecorated && function.IsNameDecorated() ? 
+            function.UndecorateFunctionName(symbolResolver) : 
+            function.RawName;
     }
 
     private ListViewItem FindMatchingFunctionInList(ListView SourceList, ListView DestinationList, List<CFunction> FunctionsList)
@@ -189,12 +191,12 @@ public partial class MainForm
             var resolvedFunction = module.ResolveFunctionForOrdinal(function.Ordinal);
             if (resolvedFunction != null)
             {
-                functionName = TryUndecorateFunction(_configuration.ViewUndecorated, resolvedFunction);
+                functionName = TryUndecorateFunction(_symbolResolver, _configuration.ViewUndecorated, resolvedFunction);
             }
         }
         else
         {
-            functionName = TryUndecorateFunction(_configuration.ViewUndecorated, function);
+            functionName = TryUndecorateFunction(_symbolResolver, _configuration.ViewUndecorated, function);
         }
 
         //
@@ -202,7 +204,7 @@ public partial class MainForm
         //
         if (string.IsNullOrEmpty(functionName) && _configuration.UseSymbols)
         {
-            var moduleBase = CSymbolResolver.RetrieveCachedSymModule(module.FileName);
+            var moduleBase = _symbolResolver.RetrieveCachedSymModule(module.FileName);
             if (moduleBase != IntPtr.Zero)
             {
                 UInt64 functionAddress = 0;
@@ -226,11 +228,11 @@ public partial class MainForm
                 if (functionAddress != 0)
                 {
                     var symAddress = Convert.ToUInt64(moduleBase) + functionAddress;
-                    if (CSymbolResolver.QuerySymbolForAddress(symAddress, out string symName))
+                    if (_symbolResolver.QuerySymbolForAddress(symAddress, out string symName))
                     {
                         function.IsNameFromSymbols = true;
                         function.RawName = symName;
-                        functionName = TryUndecorateFunction(_configuration.ViewUndecorated, function);
+                        functionName = TryUndecorateFunction(_symbolResolver,_configuration.ViewUndecorated, function);
                     }
                 }
             }
@@ -529,7 +531,7 @@ public partial class MainForm
     /// <param name="cacheType"></param>
     private void LVFunctionsSort(ListView listView, int columnIndex, SortOrder sortOrder, List<CFunction> data, DisplayCacheType cacheType)
     {
-        IComparer<CFunction> funcComparer = new CFunctionComparer(sortOrder, columnIndex);
+        IComparer<CFunction> funcComparer = new CFunctionComparer(sortOrder, columnIndex, _symbolResolver);
         data.Sort(funcComparer);
         //
         // Reset listview items cache.

--- a/src/WinDepends/MainForm/MainForm.cs
+++ b/src/WinDepends/MainForm/MainForm.cs
@@ -6,7 +6,7 @@
 *
 *  VERSION:     1.00
 *
-*  DATE:        26 May 2026
+*  DATE:        27 May 2026
 *  
 *  Codename:    VasilEk
 *
@@ -49,6 +49,11 @@ public partial class MainForm : Form
     /// Depends-core interface class.
     /// </summary>
     readonly CCoreClient _coreClient;
+
+    /// <summary>
+    /// Symbol resolver class.
+    /// </summary>
+    readonly CSymbolResolver _symbolResolver = new();
 
     /// <summary>
     /// Depends current context, must be initialized.
@@ -183,15 +188,17 @@ public partial class MainForm : Form
         CPathResolver.UserDirectoriesKM = _configuration.UserSearchOrderDirectoriesKM;
         CPathResolver.UserDirectoriesUM = _configuration.UserSearchOrderDirectoriesUM;
 
-        var dbghelpInit = CSymbolResolver.AllocateSymbolResolver(_configuration.SymbolsDllPath,
+        var dbghelpInit = _symbolResolver.AllocateSymbolResolver(_configuration.SymbolsDllPath,
                 _configuration.SymbolsStorePath, _configuration.UseSymbols);
 
         if (dbghelpInit != SymbolResolverInitResult.InitializationFailure &&
             dbghelpInit != SymbolResolverInitResult.DllLoadFailure)
         {
-            _configuration.SymbolsDllPath = CSymbolResolver.DllPath;
-            _configuration.SymbolsStorePath = CSymbolResolver.StorePath;
+            _configuration.SymbolsDllPath = _symbolResolver.DllPath;
+            _configuration.SymbolsStorePath = _symbolResolver.StorePath;
         }
+
+        _symbolResolver.SymbolLoadStatusChanged += SymbolResolver_SymbolLoadStatusChanged;
 
         //
         // Check for command line parameters.
@@ -250,6 +257,46 @@ public partial class MainForm : Form
         _functionLookupTimer.Tick += FunctionLookupTimer_Tick;
     }
 
+    private void SymbolResolver_SymbolLoadStatusChanged(object? sender, SymbolLoadStatusChangedEventArgs e)
+    {
+        if (_shutdownInProgress || IsDisposed || !IsHandleCreated)
+            return;
+
+        if (InvokeRequired)
+        {
+            BeginInvoke(new Action(() =>
+            {
+                if (_shutdownInProgress || IsDisposed || !IsHandleCreated)
+                    return;
+
+                SymbolResolver_SymbolLoadStatusChanged(sender, e);
+            }));
+            return;
+        }
+
+        switch (e.State)
+        {
+            case SymbolLoadState.Queued:
+            case SymbolLoadState.Loading:
+                UpdateOperationStatus(e.Message);
+                break;
+
+            case SymbolLoadState.Loaded:
+            case SymbolLoadState.Cancelled:
+            case SymbolLoadState.Idle:
+                UpdateOperationStatus(string.Empty);
+                break;
+
+            case SymbolLoadState.Failed:
+                UpdateOperationStatus(string.Empty);
+                if (!string.IsNullOrEmpty(e.Message))
+                {
+                    AddLogMessage(e.Message, LogMessageType.ErrorOrWarning);
+                }
+                break;
+        }
+    }
+
     private void ShowTypeSearchHint(Control owner, string text)
     {
         Point screenPoint;
@@ -292,24 +339,24 @@ public partial class MainForm : Form
         switch (result)
         {
             case SymbolResolverInitResult.DllLoadFailure:
-                AddLogMessage($"DBGHELP is not initialized, \"{CSymbolResolver.DllPath}\" is not loaded",
+                AddLogMessage($"DBGHELP is not initialized, \"{_symbolResolver.DllPath}\" is not loaded",
                     LogMessageType.ErrorOrWarning);
                 break;
             case SymbolResolverInitResult.InitializationFailure:
-                AddLogMessage($"DBGHELP initialization failed for \"{CSymbolResolver.DllPath}\", " +
-                    $"store \"{CSymbolResolver.StorePath}\"", LogMessageType.ErrorOrWarning);
+                AddLogMessage($"DBGHELP initialization failed for \"{_symbolResolver.DllPath}\", " +
+                    $"store \"{_symbolResolver.StorePath}\"", LogMessageType.ErrorOrWarning);
                 break;
             case SymbolResolverInitResult.SuccessWithSymbols:
-                AddLogMessage($"DBGHELP initialized using \"{CSymbolResolver.DllPath}\", " +
-                    $"store \"{CSymbolResolver.StorePath}\"", LogMessageType.Information);
+                AddLogMessage($"DBGHELP initialized using \"{_symbolResolver.DllPath}\", " +
+                    $"store \"{_symbolResolver.StorePath}\"", LogMessageType.Information);
                 break;
             case SymbolResolverInitResult.SuccessForUndecorationOnly:
-                AddLogMessage($"DBGHELP initialized (undecoration only) using \"{CSymbolResolver.DllPath}\", " +
-                    $"store \"{CSymbolResolver.StorePath}\"", LogMessageType.Information);
+                AddLogMessage($"DBGHELP initialized (undecoration only) using \"{_symbolResolver.DllPath}\", " +
+                    $"store \"{_symbolResolver.StorePath}\"", LogMessageType.Information);
                 break;
             case SymbolResolverInitResult.SuccessWithSymbolsAlternateDll:
-                AddLogMessage($"DBGHELP initialized with best available \"{CSymbolResolver.DllPath}\", " +
-                    $"store \"{CSymbolResolver.StorePath}\"", LogMessageType.Information);
+                AddLogMessage($"DBGHELP initialized with best available \"{_symbolResolver.DllPath}\", " +
+                    $"store \"{_symbolResolver.StorePath}\"", LogMessageType.Information);
                 break;
         }
     }
@@ -662,6 +709,8 @@ public partial class MainForm : Form
         }
         finally
         {
+            _symbolResolver.SymbolLoadStatusChanged -= SymbolResolver_SymbolLoadStatusChanged;
+            _symbolResolver.Dispose();
             _coreClient?.Dispose();
         }
     }
@@ -696,19 +745,19 @@ public partial class MainForm : Form
                 _configuration.SymbolsStorePath = symStorePath;
             }
 
-            CSymbolResolver.ReleaseSymbolResolver();
-            var result = CSymbolResolver.AllocateSymbolResolver(symDllPath, symStorePath, _configuration.UseSymbols);
+            _symbolResolver.ReleaseSymbolResolver();
+            var result = _symbolResolver.AllocateSymbolResolver(symDllPath, symStorePath, _configuration.UseSymbols);
             if (result != SymbolResolverInitResult.InitializationFailure &&
                 result != SymbolResolverInitResult.DllLoadFailure)
             {
-                _configuration.SymbolsDllPath = CSymbolResolver.DllPath;
-                _configuration.SymbolsStorePath = CSymbolResolver.StorePath;
+                _configuration.SymbolsDllPath = _symbolResolver.DllPath;
+                _configuration.SymbolsStorePath = _symbolResolver.StorePath;
             }
             LogSymbolsInitializationResult(result);
         }
         else
         {
-            if (CSymbolResolver.ReleaseSymbolResolver())
+            if (_symbolResolver.ReleaseSymbolResolver())
             {
                 AddLogMessage($"Debug symbols deallocated", LogMessageType.Information);
             }
@@ -1641,12 +1690,10 @@ public partial class MainForm : Form
 
     private void PreloadSymbolForSelectedModule(CModule module)
     {
-        var symBase = CSymbolResolver.RetrieveCachedSymModule(module.FileName);
+        var symBase = _symbolResolver.RetrieveCachedSymModule(module.FileName);
         if (symBase == IntPtr.Zero)
         {
-            UpdateOperationStatus($"Please wait, loading symbols for \"{module.FileName}\"...");
-            CSymbolResolver.LoadModule(module.FileName, 0);
-            UpdateOperationStatus(string.Empty);
+            _symbolResolver.RequestModulePreload(module.FileName, 0);
         }
     }
 

--- a/src/WinDepends/MainForm/MainForm.cs
+++ b/src/WinDepends/MainForm/MainForm.cs
@@ -6,7 +6,7 @@
 *
 *  VERSION:     1.00
 *
-*  DATE:        27 May 2026
+*  DATE:        28 May 2026
 *  
 *  Codename:    VasilEk
 *
@@ -264,13 +264,20 @@ public partial class MainForm : Form
 
         if (InvokeRequired)
         {
-            BeginInvoke(new Action(() =>
+            try
             {
-                if (_shutdownInProgress || IsDisposed || !IsHandleCreated)
-                    return;
+                BeginInvoke(new Action(() =>
+                {
+                    if (_shutdownInProgress || IsDisposed || !IsHandleCreated)
+                        return;
 
-                SymbolResolver_SymbolLoadStatusChanged(sender, e);
-            }));
+                    SymbolResolver_SymbolLoadStatusChanged(sender, e);
+                }));
+            }
+            catch
+            {
+                // Ignore shutdown race.
+            }
             return;
         }
 
@@ -278,21 +285,15 @@ public partial class MainForm : Form
         {
             case SymbolLoadState.Queued:
             case SymbolLoadState.Loading:
+            case SymbolLoadState.Loaded:
                 UpdateOperationStatus(e.Message);
                 break;
-
-            case SymbolLoadState.Loaded:
             case SymbolLoadState.Cancelled:
             case SymbolLoadState.Idle:
                 UpdateOperationStatus(string.Empty);
                 break;
-
             case SymbolLoadState.Failed:
-                UpdateOperationStatus(string.Empty);
-                if (!string.IsNullOrEmpty(e.Message))
-                {
-                    AddLogMessage(e.Message, LogMessageType.ErrorOrWarning);
-                }
+                UpdateOperationStatus(e.Message);
                 break;
         }
     }
@@ -943,7 +944,6 @@ public partial class MainForm : Form
                         Verb = "open",
                         UseShellExecute = true
                     });
-
                 }
                 catch (Exception ex)
                 {

--- a/src/WinDepends/Models/CFunction.cs
+++ b/src/WinDepends/Models/CFunction.cs
@@ -6,7 +6,7 @@
 *
 *  VERSION:     1.00
 *
-*  DATE:        23 May 2026
+*  DATE:        28 May 2026
 *  
 *  Implementation of CFunction and CFunctionComparer classes.
 *

--- a/src/WinDepends/Models/CFunction.cs
+++ b/src/WinDepends/Models/CFunction.cs
@@ -277,11 +277,11 @@ public class CFunction
     /// Otherwise, it uses <see cref="CSymbolResolver.UndecorateFunctionName"/> to demangle the name
     /// and caches the result in <see cref="UndecoratedName"/>.
     /// </remarks>
-    public string UndecorateFunctionName()
+    public string UndecorateFunctionName(CSymbolResolver symbolResolver)
     {
         if (string.IsNullOrEmpty(UndecoratedName))
         {
-            UndecoratedName = CSymbolResolver.UndecorateFunctionName(RawName);
+            UndecoratedName = symbolResolver.UndecorateFunctionName(RawName);
         }
 
         return UndecoratedName;
@@ -761,21 +761,24 @@ public class CFunctionComparer : IComparer<CFunction>
     private readonly int _fieldIndex;
     private readonly SortOrder _sortOrder;
     private readonly StringComparer _stringComparer;
+    readonly CSymbolResolver _symbolResolver;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CFunctionComparer"/> class.
     /// </summary>
     /// <param name="sortOrder">The sort direction to apply to comparisons.</param>
     /// <param name="fieldIndex">The index of the field to compare.</param>
+    /// <param name="symbolResolver">The symbol resolver class object.</param>
     /// <remarks>
     /// This constructor configures the comparer to sort functions based on the specified field
     /// and in the specified direction.
     /// </remarks>
-    public CFunctionComparer(SortOrder sortOrder, int fieldIndex)
+    public CFunctionComparer(SortOrder sortOrder, int fieldIndex, CSymbolResolver symbolResolver)
     {
         _fieldIndex = fieldIndex;
         _sortOrder = sortOrder;
         _stringComparer = StringComparer.OrdinalIgnoreCase;
+        _symbolResolver = symbolResolver;
     }
 
     public int Compare(CFunction x, CFunction y)
@@ -847,10 +850,10 @@ public class CFunctionComparer : IComparer<CFunction>
                 {
                     // Cache UndecoratedName if needed
                     if (string.IsNullOrEmpty(x.UndecoratedName) && !string.IsNullOrEmpty(x.RawName) && x.IsNameDecorated())
-                        x.UndecorateFunctionName();
+                        x.UndecorateFunctionName(_symbolResolver);
 
                     if (string.IsNullOrEmpty(y.UndecoratedName) && !string.IsNullOrEmpty(y.RawName) && y.IsNameDecorated())
-                        y.UndecorateFunctionName();
+                        y.UndecorateFunctionName(_symbolResolver);
 
                     string nameX = !string.IsNullOrEmpty(x.UndecoratedName) ? x.UndecoratedName : x.RawName;
                     string nameY = !string.IsNullOrEmpty(y.UndecoratedName) ? y.UndecoratedName : y.RawName;

--- a/src/WinDepends/Symbols/CSymbolResolver.cs
+++ b/src/WinDepends/Symbols/CSymbolResolver.cs
@@ -6,7 +6,7 @@
 *
 *  VERSION:     1.00
 *  
-*  DATE:        26 May 2026
+*  DATE:        27 May 2026
 *
 *  MS Symbols resolver support class.
 *
@@ -55,10 +55,28 @@ public enum SymbolResolverInitResult
     SuccessWithSymbolsAlternateDll = 3
 }
 
+public enum SymbolLoadState
+{
+    Idle,
+    Queued,
+    Loading,
+    Loaded,
+    Failed,
+    Cancelled
+}
+
+public sealed class SymbolLoadStatusChangedEventArgs : EventArgs
+{
+    public string FileName { get; init; }
+    public SymbolLoadState State { get; init; }
+    public string Message { get; init; }
+    public Exception Error { get; init; }
+}
+
 /// <summary>
 /// Provides functionality for resolving symbols from Windows binary files using the DbgHelp API.
 /// </summary>
-public static class CSymbolResolver
+public sealed class CSymbolResolver : IDisposable
 {
     #region "P/Invoke stuff"
     public const uint SYMOPT_CASE_INSENSITIVE = 0x00000001;
@@ -94,67 +112,28 @@ public static class CSymbolResolver
     public const uint SYMOPT_DISABLE_SRVSTAR_ON_STARTUP = 0x40000000;
     public const uint SYMOPT_DEBUG = 0x80000000;
 
-    /// <summary>
-    /// Controls the behavior of symbol name undecoration.
-    /// </summary>
     [Flags]
     public enum UNDNAME : uint
     {
-        /// <summary>Undecorate 32-bit decorated names.</summary>
         Decode32Bit = 0x0800,
-
-        /// <summary>Enable full undecoration.</summary>
         Complete = 0x0000,
-
-        /// <summary>Undecorate only the name for primary declaration. Returns [scope::]name. Does expand template parameters.</summary>
         NameOnly = 0x1000,
-
-        /// <summary>Disable expansion of access specifiers for members.</summary>
         NoAccessSpecifiers = 0x0080,
-
-        /// <summary>Disable expansion of the declaration language specifier.</summary>
         NoAllocateLanguage = 0x0010,
-
-        /// <summary>Disable expansion of the declaration model.</summary>
         NoAllocationModel = 0x0008,
-
-        /// <summary>Do not undecorate function arguments.</summary>
         NoArguments = 0x2000,
-
-        /// <summary>Disable expansion of CodeView modifiers on the this type for primary declaration.</summary>
         NoCVThisType = 0x0040,
-
-        /// <summary>Disable expansion of return types for primary declarations.</summary>
         NoFunctionReturns = 0x0004,
-
-        /// <summary>Remove leading underscores from Microsoft keywords.</summary>
         NoLeadingUndersCores = 0x0001,
-
-        /// <summary>Disable expansion of the static or virtual attribute of members.</summary>
         NoMemberType = 0x0200,
-
-        /// <summary>Disable expansion of Microsoft keywords.</summary>
         NoMsKeyWords = 0x0002,
-
-        /// <summary>Disable expansion of Microsoft keywords on the this type for primary declaration.</summary>
         NoMsThisType = 0x0020,
-
-        /// <summary>Disable expansion of the Microsoft model for user-defined type returns.</summary>
         NoReturnUDTModel = 0x0400,
-
-        /// <summary>Do not undecorate special names, such as vtable, vcall, vector, metatype, and so on.</summary>
         NoSpecialSyms = 0x4000,
-
-        /// <summary>Disable all modifiers on the this type.</summary>
         NoThisType = 0x0060,
-
-        /// <summary>Disable expansion of throw-signatures for functions and pointers to functions.</summary>
         NoThrowSignatures = 0x0100,
     }
 
-    /// <summary>
-    /// Contains information about a symbol.
-    /// </summary>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct SYMBOL_INFO
     {
@@ -177,9 +156,7 @@ public static class CSymbolResolver
         public string Name;
     }
 
-    /// <summary>Maximum length of a symbol name.</summary>
     const UInt32 MAX_SYM_NAME = 2000;
-    /// <summary>Size of the SYMBOL_INFO structure excluding the name field.</summary>
     static readonly UInt32 SIZE_OF_SYMBOL_INFO = (uint)Marshal.SizeOf<SYMBOL_INFO>() - (MAX_SYM_NAME * 2);
 
     [UnmanagedFunctionPointer(CallingConvention.Winapi, SetLastError = true)]
@@ -206,10 +183,10 @@ public static class CSymbolResolver
 
     [UnmanagedFunctionPointer(CallingConvention.Winapi, SetLastError = true)]
     delegate bool SymFromAddrDelegate(
-            SafeProcessHandle hProcess,
-            UInt64 Address,
-            out UInt64 Displacement,
-            ref SYMBOL_INFO Symbol);
+        SafeProcessHandle hProcess,
+        UInt64 Address,
+        out UInt64 Displacement,
+        ref SYMBOL_INFO Symbol);
 
     [UnmanagedFunctionPointer(CallingConvention.Winapi, SetLastError = true)]
     delegate uint SymGetOptionsDelegate();
@@ -225,29 +202,70 @@ public static class CSymbolResolver
         UNDNAME flags);
     #endregion
 
-    // P/Invoke delegates
-    static SymLoadModuleExDelegate SymLoadModuleEx;
-    static SymUnloadModule64Delegate SymUnloadModule64;
-    static SymInitializeDelegate SymInitialize;
-    static SymGetOptionsDelegate SymGetOptions;
-    static SymSetOptionsDelegate SymSetOptions;
-    static SymCleanupDelegate SymCleanup;
-    static SymFromAddrDelegate SymFromAddr;
-    static UnDecorateSymbolNameDelegate UnDecorateSymbolName;
-    static IntPtr DbgHelpModule { get; set; } = IntPtr.Zero;
-    static IntPtr CachedSymModuleBase { get; set; } = IntPtr.Zero;
-    static string CachedSymModuleName { get; set; } = string.Empty;
-    static bool SymbolsInitialized { get; set; }
-    public static bool UndecorationReady { get; set; }
-    public static string DllPath { get; set; }
-    public static string StorePath { get; set; }
+    SymLoadModuleExDelegate SymLoadModuleEx;
+    SymUnloadModule64Delegate SymUnloadModule64;
+    SymInitializeDelegate SymInitialize;
+    SymGetOptionsDelegate SymGetOptions;
+    SymSetOptionsDelegate SymSetOptions;
+    SymCleanupDelegate SymCleanup;
+    SymFromAddrDelegate SymFromAddr;
+    UnDecorateSymbolNameDelegate UnDecorateSymbolName;
+
+    readonly object _stateLock = new();
+    readonly object _dbgHelpLock = new();
+    readonly AutoResetEvent _preloadSignal = new(false);
+
+    Thread _preloadWorkerThread;
+    bool _workerStarted;
+    volatile bool _disposeRequested;
+
+    string _pendingModuleFileName = string.Empty;
+    UInt64 _pendingModuleBaseAddress;
+    int _pendingRequestId;
+
+    string _activeModuleFileName = string.Empty;
+
+    string _nativeLoadedModuleFileName = string.Empty;
+    IntPtr _nativeLoadedModuleBase = IntPtr.Zero;
+
+    IntPtr DbgHelpModule { get; set; } = IntPtr.Zero;
+
+    public bool SymbolsInitialized { get; private set; }
+    public bool UndecorationReady { get; private set; }
+    public string DllPath { get; private set; }
+    public string StorePath { get; private set; }
+
+    public event EventHandler<SymbolLoadStatusChangedEventArgs> SymbolLoadStatusChanged;
 
     static readonly SafeProcessHandle CurrentProcess = new(new IntPtr(-1), false);
 
-    /// <summary>
-    /// Clears all symbol-related function delegates.
-    /// </summary>
-    private static void ClearSymbolsDelegates()
+    private void RaiseSymbolLoadStatusChanged(string fileName, SymbolLoadState state, string message, Exception error = null)
+    {
+        SymbolLoadStatusChanged?.Invoke(this, new SymbolLoadStatusChangedEventArgs
+        {
+            FileName = fileName,
+            State = state,
+            Message = message,
+            Error = error
+        });
+    }
+
+    private void EnsurePreloadWorkerStarted()
+    {
+        if (_workerStarted)
+            return;
+
+        _preloadWorkerThread = new Thread(PreloadWorkerProc)
+        {
+            IsBackground = true,
+            Name = "CSymbolResolver.PreloadWorker"
+        };
+
+        _workerStarted = true;
+        _preloadWorkerThread.Start();
+    }
+
+    private void ClearSymbolsDelegates()
     {
         SymLoadModuleEx = null;
         SymUnloadModule64 = null;
@@ -258,48 +276,46 @@ public static class CSymbolResolver
         SymGetOptions = null;
     }
 
-    /// <summary>
-    /// Clears the undecorate symbol name function delegate.
-    /// </summary>
-    private static void ClearUndecorateDelegate()
+    private void ClearUndecorateDelegate()
     {
         UnDecorateSymbolName = null;
     }
 
-    /// <summary>
-    /// Initializes the undecorate symbol name delegate.
-    /// </summary>
-    /// <returns>True if successful, false otherwise.</returns>
-    private static bool InitializeUndecorateDelegate()
+    private bool InitializeUndecorateDelegate()
     {
         try
         {
-            UnDecorateSymbolName = Marshal.GetDelegateForFunctionPointer<UnDecorateSymbolNameDelegate>(NativeMethods.GetProcAddress(DbgHelpModule, "UnDecorateSymbolNameW"));
+            UnDecorateSymbolName = Marshal.GetDelegateForFunctionPointer<UnDecorateSymbolNameDelegate>(
+                NativeMethods.GetProcAddress(DbgHelpModule, "UnDecorateSymbolNameW"));
         }
         catch
         {
             UnDecorateSymbolName = null;
         }
 
-        return (UnDecorateSymbolName != null);
+        return UnDecorateSymbolName != null;
     }
 
-    /// <summary>
-    /// Initializes all symbol-related function delegates.
-    /// </summary>
-    /// <returns>True if all delegates were initialized successfully, false otherwise.</returns>
-    private static bool InitializeSymbolsDelegates()
+    private bool InitializeSymbolsDelegates()
     {
         bool bResult;
+
         try
         {
-            SymLoadModuleEx = Marshal.GetDelegateForFunctionPointer<SymLoadModuleExDelegate>(NativeMethods.GetProcAddress(DbgHelpModule, "SymLoadModuleExW"));
-            SymUnloadModule64 = Marshal.GetDelegateForFunctionPointer<SymUnloadModule64Delegate>(NativeMethods.GetProcAddress(DbgHelpModule, "SymUnloadModule64"));
-            SymGetOptions = Marshal.GetDelegateForFunctionPointer<SymGetOptionsDelegate>(NativeMethods.GetProcAddress(DbgHelpModule, "SymGetOptions"));
-            SymSetOptions = Marshal.GetDelegateForFunctionPointer<SymSetOptionsDelegate>(NativeMethods.GetProcAddress(DbgHelpModule, "SymSetOptions"));
-            SymInitialize = Marshal.GetDelegateForFunctionPointer<SymInitializeDelegate>(NativeMethods.GetProcAddress(DbgHelpModule, "SymInitializeW"));
-            SymFromAddr = Marshal.GetDelegateForFunctionPointer<SymFromAddrDelegate>(NativeMethods.GetProcAddress(DbgHelpModule, "SymFromAddrW"));
-            SymCleanup = Marshal.GetDelegateForFunctionPointer<SymCleanupDelegate>(NativeMethods.GetProcAddress(DbgHelpModule, "SymCleanup"));
+            SymLoadModuleEx = Marshal.GetDelegateForFunctionPointer<SymLoadModuleExDelegate>(
+                NativeMethods.GetProcAddress(DbgHelpModule, "SymLoadModuleExW"));
+            SymUnloadModule64 = Marshal.GetDelegateForFunctionPointer<SymUnloadModule64Delegate>(
+                NativeMethods.GetProcAddress(DbgHelpModule, "SymUnloadModule64"));
+            SymGetOptions = Marshal.GetDelegateForFunctionPointer<SymGetOptionsDelegate>(
+                NativeMethods.GetProcAddress(DbgHelpModule, "SymGetOptions"));
+            SymSetOptions = Marshal.GetDelegateForFunctionPointer<SymSetOptionsDelegate>(
+                NativeMethods.GetProcAddress(DbgHelpModule, "SymSetOptions"));
+            SymInitialize = Marshal.GetDelegateForFunctionPointer<SymInitializeDelegate>(
+                NativeMethods.GetProcAddress(DbgHelpModule, "SymInitializeW"));
+            SymFromAddr = Marshal.GetDelegateForFunctionPointer<SymFromAddrDelegate>(
+                NativeMethods.GetProcAddress(DbgHelpModule, "SymFromAddrW"));
+            SymCleanup = Marshal.GetDelegateForFunctionPointer<SymCleanupDelegate>(
+                NativeMethods.GetProcAddress(DbgHelpModule, "SymCleanup"));
 
             if (SymLoadModuleEx == null
                 || SymUnloadModule64 == null
@@ -316,7 +332,6 @@ public static class CSymbolResolver
             {
                 bResult = true;
             }
-
         }
         catch
         {
@@ -327,26 +342,11 @@ public static class CSymbolResolver
         return bResult;
     }
 
-    /// <summary>
-    /// Initializes the symbol resolver with the specified parameters.
-    /// </summary>
-    /// <param name="dllPath">The path to DbgHelp.dll.</param>
-    /// <param name="storePath">The path to store symbol files.</param>
-    /// <param name="useSymbols">Indicates whether to use symbols or only name undecoration.</param>
-    /// <returns>
-    /// A <see cref="SymbolResolverInitResult"/> value indicating the result of the initialization:
-    /// <list type="bullet">
-    ///   <item><description><see cref="SymbolResolverInitResult.DllLoadFailure"/> if DbgHelp.dll could not be loaded</description></item>
-    ///   <item><description><see cref="SymbolResolverInitResult.InitializationFailure"/> if initialization failed</description></item>
-    ///   <item><description><see cref="SymbolResolverInitResult.SuccessWithSymbolsAlternateDll"/> if successfully initialized with a better dbghelp.dll</description></item>
-    ///   <item><description><see cref="SymbolResolverInitResult.SuccessWithSymbols"/> if successfully initialized with symbols</description></item>
-    ///   <item><description><see cref="SymbolResolverInitResult.SuccessForUndecorationOnly"/> if successfully initialized for name undecoration only</description></item>
-    /// </list>
-    /// </returns>
-    public static SymbolResolverInitResult AllocateSymbolResolver(string dllPath, string storePath, bool useSymbols)
+    public SymbolResolverInitResult AllocateSymbolResolver(string dllPath, string storePath, bool useSymbols)
     {
         DllPath = dllPath;
         StorePath = storePath;
+
         string candidatePath = dllPath;
         bool usedAlternateDll = false;
 
@@ -364,16 +364,13 @@ public static class CSymbolResolver
                     usedAlternateDll = !IsSystemDbgHelp(candidatePath);
                 }
             }
-            else
+            else if (IsSystemDbgHelp(candidatePath))
             {
-                if (IsSystemDbgHelp(candidatePath))
+                string best = FindDbgHelpDll();
+                if (!string.IsNullOrEmpty(best) && !PathsEqual(best, candidatePath))
                 {
-                    var best = FindDbgHelpDll();
-                    if (!string.IsNullOrEmpty(best) && !PathsEqual(best, candidatePath))
-                    {
-                        usedAlternateDll = !IsSystemDbgHelp(best);
-                        candidatePath = best;
-                    }
+                    usedAlternateDll = !IsSystemDbgHelp(best);
+                    candidatePath = best;
                 }
             }
         }
@@ -383,39 +380,43 @@ public static class CSymbolResolver
             usedAlternateDll = false;
         }
 
-        DbgHelpModule = NativeMethods.LoadLibraryEx(candidatePath, IntPtr.Zero, 0);
-        if (DbgHelpModule == IntPtr.Zero && !string.Equals(candidatePath, CConsts.DbgHelpDll, StringComparison.OrdinalIgnoreCase))
+        lock (_dbgHelpLock)
         {
-            DbgHelpModule = NativeMethods.LoadLibraryEx(CConsts.DbgHelpDll, IntPtr.Zero, 0);
-            if (DbgHelpModule != IntPtr.Zero)
+            DbgHelpModule = NativeMethods.LoadLibraryEx(candidatePath, IntPtr.Zero, 0);
+            if (DbgHelpModule == IntPtr.Zero &&
+                !string.Equals(candidatePath, CConsts.DbgHelpDll, StringComparison.OrdinalIgnoreCase))
             {
-                DllPath = CConsts.DbgHelpDll;
-                usedAlternateDll = false;
+                DbgHelpModule = NativeMethods.LoadLibraryEx(CConsts.DbgHelpDll, IntPtr.Zero, 0);
+                if (DbgHelpModule != IntPtr.Zero)
+                {
+                    DllPath = CConsts.DbgHelpDll;
+                    usedAlternateDll = false;
+                }
             }
-        }
-        else
-        {
-            DllPath = candidatePath;
-        }
+            else
+            {
+                DllPath = candidatePath;
+            }
 
-        if (DbgHelpModule == IntPtr.Zero)
-        {
-            return SymbolResolverInitResult.DllLoadFailure;
-        }
+            if (DbgHelpModule == IntPtr.Zero)
+            {
+                return SymbolResolverInitResult.DllLoadFailure;
+            }
 
-        UndecorationReady = DbgHelpModule != IntPtr.Zero && InitializeUndecorateDelegate();
+            UndecorationReady = InitializeUndecorateDelegate();
 
-        if (useSymbols && DbgHelpModule != IntPtr.Zero && InitializeSymbolsDelegates())
-        {
-            // No SYMOPT_UNDNAME as we have a special GUI option for it.
-            SymSetOptions(
-                (SymGetOptions() |
-                 SYMOPT_DEFERRED_LOADS |
-                 SYMOPT_FAIL_CRITICAL_ERRORS |
-                 SYMOPT_PUBLICS_ONLY
-                ) & ~SYMOPT_UNDNAME);
+            if (useSymbols && InitializeSymbolsDelegates())
+            {
+                SymSetOptions(
+                    (SymGetOptions() |
+                     SYMOPT_DEFERRED_LOADS |
+                     SYMOPT_FAIL_CRITICAL_ERRORS |
+                     SYMOPT_PUBLICS_ONLY
+                    // | SYMOPT_NO_PROMPTS
+                    ) & ~SYMOPT_UNDNAME);
 
-            SymbolsInitialized = SymInitialize(CurrentProcess, StorePath, false);
+                SymbolsInitialized = SymInitialize(CurrentProcess, StorePath, false);
+            }
         }
 
         if (useSymbols)
@@ -423,181 +424,370 @@ public static class CSymbolResolver
             if (!SymbolsInitialized)
                 return SymbolResolverInitResult.InitializationFailure;
 
+            EnsurePreloadWorkerStarted();
+
             return usedAlternateDll
                 ? SymbolResolverInitResult.SuccessWithSymbolsAlternateDll
                 : SymbolResolverInitResult.SuccessWithSymbols;
         }
-        else
+
+        return UndecorationReady
+            ? SymbolResolverInitResult.SuccessForUndecorationOnly
+            : SymbolResolverInitResult.InitializationFailure;
+    }
+
+    public void RequestModulePreload(string fileName, UInt64 baseAddress)
+    {
+        string loadedFileName;
+        IntPtr loadedBase;
+
+        if (!SymbolsInitialized || string.IsNullOrEmpty(fileName))
+            return;
+
+        lock (_dbgHelpLock)
         {
-            return UndecorationReady ? SymbolResolverInitResult.SuccessForUndecorationOnly : SymbolResolverInitResult.InitializationFailure;
+            loadedFileName = _nativeLoadedModuleFileName;
+            loadedBase = _nativeLoadedModuleBase;
+        }
+
+        lock (_stateLock)
+        {
+            if (loadedBase != IntPtr.Zero &&
+                string.Equals(loadedFileName, fileName, StringComparison.OrdinalIgnoreCase) &&
+                string.IsNullOrEmpty(_pendingModuleFileName))
+            {
+                _activeModuleFileName = fileName;
+                return;
+            }
+
+            if (string.Equals(_pendingModuleFileName, fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            _pendingModuleFileName = fileName;
+            _pendingModuleBaseAddress = baseAddress;
+            _pendingRequestId++;
+        }
+
+        RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Queued,
+            $"Loading symbols for \"{fileName}\"...");
+
+        _preloadSignal.Set();
+    }
+
+    private void PreloadWorkerProc()
+    {
+        while (true)
+        {
+            string fileName;
+            UInt64 baseAddress;
+            int requestId;
+            bool alreadyLoaded;
+            bool loadSucceeded;
+            IntPtr loadedBase;
+            string nativeLoadedName;
+            int lastError;
+
+            _preloadSignal.WaitOne();
+
+            if (_disposeRequested)
+                break;
+
+            lock (_stateLock)
+            {
+                fileName = _pendingModuleFileName;
+                baseAddress = _pendingModuleBaseAddress;
+                requestId = _pendingRequestId;
+
+                _pendingModuleFileName = string.Empty;
+                _pendingModuleBaseAddress = 0;
+            }
+
+            if (string.IsNullOrEmpty(fileName))
+                continue;
+
+            try
+            {
+                RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Loading,
+                    $"Loading symbols for \"{fileName}\"...");
+
+                lock (_dbgHelpLock)
+                {
+                    alreadyLoaded = string.Equals(_nativeLoadedModuleFileName, fileName, StringComparison.OrdinalIgnoreCase)
+                        && _nativeLoadedModuleBase != IntPtr.Zero;
+                }
+
+                loadSucceeded = alreadyLoaded;
+                loadedBase = IntPtr.Zero;
+                nativeLoadedName = string.Empty;
+                lastError = 0;
+
+                if (!alreadyLoaded)
+                {
+                    lock (_dbgHelpLock)
+                    {
+                        if (_disposeRequested)
+                            break;
+
+                        loadedBase = LoadModuleNative(fileName, baseAddress, out lastError);
+                        if (loadedBase != IntPtr.Zero)
+                        {
+                            _nativeLoadedModuleFileName = fileName;
+                            _nativeLoadedModuleBase = loadedBase;
+                            nativeLoadedName = fileName;
+                            loadSucceeded = true;
+                        }
+                        else
+                        {
+                            _nativeLoadedModuleFileName = string.Empty;
+                            _nativeLoadedModuleBase = IntPtr.Zero;
+                        }
+                    }
+                }
+                else
+                {
+                    lock (_dbgHelpLock)
+                    {
+                        nativeLoadedName = _nativeLoadedModuleFileName;
+                        loadedBase = _nativeLoadedModuleBase;
+                    }
+                }
+
+                if (!loadSucceeded)
+                {
+                    RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Failed,
+                        lastError != 0
+                            ? $"Symbol load failed for \"{fileName}\", error 0x{lastError:X8}."
+                            : $"Symbol load failed for \"{fileName}\".");
+                    continue;
+                }
+
+                lock (_stateLock)
+                {
+                    if (string.Equals(nativeLoadedName, fileName, StringComparison.OrdinalIgnoreCase) &&
+                        loadedBase != IntPtr.Zero)
+                    {
+                        _activeModuleFileName = fileName;
+                    }
+                }
+
+                lock (_stateLock)
+                {
+                    if (requestId != _pendingRequestId)
+                    {
+                        RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Cancelled, string.Empty);
+                        continue;
+                    }
+                }
+
+                RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Loaded, string.Empty);
+            }
+            catch (Exception ex)
+            {
+                RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Failed,
+                    $"Symbol load failed for \"{fileName}\": {ex.Message}", ex);
+            }
+        }
+
+        if (!_disposeRequested)
+        {
+            RaiseSymbolLoadStatusChanged(string.Empty, SymbolLoadState.Idle, string.Empty);
         }
     }
 
-    public static IntPtr RetrieveCachedSymModule(string ModuleName)
+    private IntPtr LoadModuleNative(string fileName, UInt64 baseAddress, out int lastError)
     {
-        if (string.IsNullOrEmpty(CachedSymModuleName))
+        IntPtr symModule;
+
+        lastError = 0;
+
+        if (!SymbolsInitialized || SymLoadModuleEx == null)
             return IntPtr.Zero;
 
-        if (CachedSymModuleName.Equals(ModuleName, StringComparison.OrdinalIgnoreCase))
-            return CachedSymModuleBase;
+        ClearLoadedModuleNative();
 
-        return IntPtr.Zero;
-    }
+        symModule = SymLoadModuleEx(CurrentProcess,
+            IntPtr.Zero,
+            fileName,
+            null,
+            baseAddress,
+            0,
+            IntPtr.Zero,
+            0);
 
-    public static void CacheSymModule(IntPtr ModuleBase, string ModuleName)
-    {
-        if (ModuleBase == IntPtr.Zero) return;
-        if (string.IsNullOrEmpty(ModuleName)) return;
-
-        CachedSymModuleName = ModuleName;
-        CachedSymModuleBase = ModuleBase;
-    }
-
-    public static bool ClearCachedSymModule()
-    {
-        var result = false;
-        if (CachedSymModuleBase != IntPtr.Zero)
+        if (symModule == IntPtr.Zero)
         {
-            result = SymUnloadModule64(CurrentProcess, CachedSymModuleBase);
-            CachedSymModuleBase = IntPtr.Zero;
-            CachedSymModuleName = string.Empty;
+            lastError = Marshal.GetLastWin32Error();
+        }
+
+        return symModule;
+    }
+
+    private bool ClearLoadedModuleNative()
+    {
+        bool result = false;
+
+        if (_nativeLoadedModuleBase != IntPtr.Zero)
+        {
+            if (SymUnloadModule64 != null)
+            {
+                result = SymUnloadModule64(CurrentProcess, _nativeLoadedModuleBase);
+            }
+        }
+
+        _nativeLoadedModuleBase = IntPtr.Zero;
+        _nativeLoadedModuleFileName = string.Empty;
+
+        return result;
+    }
+
+    public IntPtr RetrieveCachedSymModule(string moduleName)
+    {
+        lock (_dbgHelpLock)
+        {
+            if (string.IsNullOrEmpty(moduleName))
+                return IntPtr.Zero;
+
+            if (string.Equals(_nativeLoadedModuleFileName, moduleName, StringComparison.OrdinalIgnoreCase))
+                return _nativeLoadedModuleBase;
+
+            return IntPtr.Zero;
+        }
+    }
+
+    public bool ClearCachedSymModule()
+    {
+        bool result;
+
+        lock (_dbgHelpLock)
+        {
+            result = ClearLoadedModuleNative();
+        }
+
+        lock (_stateLock)
+        {
+            _activeModuleFileName = string.Empty;
         }
 
         return result;
     }
 
-    /// <summary>
-    /// Releases all resources used by the symbol resolver.
-    /// </summary>
-    /// <returns>True if cleanup was successful, false otherwise.</returns>
-    public static bool ReleaseSymbolResolver()
+    public bool ReleaseSymbolResolver()
     {
         bool bResult = false;
 
-        if (DbgHelpModule != IntPtr.Zero)
+        lock (_dbgHelpLock)
         {
-            if (SymbolsInitialized)
+            if (DbgHelpModule != IntPtr.Zero)
             {
-                ClearCachedSymModule();
-                bResult = SymCleanup(CurrentProcess);
+                ClearLoadedModuleNative();
+
+                if (SymbolsInitialized && SymCleanup != null)
+                {
+                    bResult = SymCleanup(CurrentProcess);
+                }
+
+                NativeMethods.FreeLibrary(DbgHelpModule);
+                DbgHelpModule = IntPtr.Zero;
+
+                ClearUndecorateDelegate();
+                UndecorationReady = false;
+
+                ClearSymbolsDelegates();
+                SymbolsInitialized = false;
             }
+        }
 
-            NativeMethods.FreeLibrary(DbgHelpModule);
-            DbgHelpModule = IntPtr.Zero;
-
-            ClearUndecorateDelegate();
-            UndecorationReady = false;
-
-            ClearSymbolsDelegates();
-            SymbolsInitialized = false;
+        lock (_stateLock)
+        {
+            _pendingModuleFileName = string.Empty;
+            _pendingModuleBaseAddress = 0;
+            _pendingRequestId = 0;
+            _activeModuleFileName = string.Empty;
         }
 
         return bResult;
     }
 
-    /// <summary>
-    /// Undecorates a C++ decorated function name.
-    /// </summary>
-    /// <param name="functionName">The decorated function name.</param>
-    /// <returns>The undecorated function name, or the original name if it wasn't decorated.</returns>
-    internal static string UndecorateFunctionName(string functionName)
+    public void Dispose()
     {
-        if (!UndecorationReady)
+        _disposeRequested = true;
+        _preloadSignal.Set();
+
+        if (_preloadWorkerThread != null && _preloadWorkerThread.IsAlive)
         {
-            return functionName;
+            _preloadWorkerThread.Join();
         }
 
-        var sb = new StringBuilder(1024);
+        _preloadSignal.Dispose();
+        ReleaseSymbolResolver();
+    }
 
-        // Note: DependencyWalker uses UNDNAME.NoAllocateLanguage | UNDNAME.NoMsKeyWords | UNDNAME.NoFunctionReturns | UNDNAME.NoAccessSpecifiers
-        if (UnDecorateSymbolName(functionName, sb, sb.Capacity, UNDNAME.NoMsKeyWords) > 0)
+    internal string UndecorateFunctionName(string functionName)
+    {
+        lock (_dbgHelpLock)
         {
-            return sb.ToString();
+            if (!UndecorationReady || UnDecorateSymbolName == null)
+            {
+                return functionName;
+            }
+
+            StringBuilder sb = new(1024);
+
+            if (UnDecorateSymbolName(functionName, sb, sb.Capacity, UNDNAME.NoMsKeyWords) > 0)
+            {
+                return sb.ToString();
+            }
         }
 
         return functionName;
     }
 
-    /// <summary>
-    /// Loads a module for symbol resolution.
-    /// </summary>
-    /// <param name="fileName">The file name of the module.</param>
-    /// <param name="baseAddress">The base address of the module.</param>
-    /// <returns>The handle of the loaded module, or IntPtr.Zero if loading failed.</returns>
-    internal static IntPtr LoadModule(string fileName, UInt64 baseAddress)
-    {
-        var symModule = IntPtr.Zero;
-        if (!SymbolsInitialized)
-            return IntPtr.Zero;
-
-        ClearCachedSymModule();
-        symModule = SymLoadModuleEx(CurrentProcess,
-                                IntPtr.Zero,
-                                fileName,
-                                null,
-                                baseAddress,
-                                0,
-                                IntPtr.Zero,
-                                0);
-
-        CacheSymModule(symModule, fileName);
-        return symModule;
-    }
-
-    /// <summary>
-    /// Queries for a symbol at the specified address.
-    /// </summary>
-    /// <param name="address">The address to query.</param>
-    /// <param name="symbolName">When this method returns, contains the symbol name if found, or null if not found.</param>
-    /// <returns>True if a symbol was found at the specified address, false otherwise.</returns>
-    public static bool QuerySymbolForAddress(UInt64 address, out string symbolName)
+    public bool QuerySymbolForAddress(UInt64 address, out string symbolName)
     {
         symbolName = null;
 
-        if (!SymbolsInitialized)
+        lock (_dbgHelpLock)
         {
-            return false;
-        }
-
-        var symbolInfo = new SYMBOL_INFO
-        {
-            SizeOfStruct = SIZE_OF_SYMBOL_INFO,
-            MaxNameLen = MAX_SYM_NAME
-        };
-
-        if (SymFromAddr(CurrentProcess, address, out ulong displacement, ref symbolInfo))
-        {
-            if (displacement != 0)
+            if (!SymbolsInitialized || SymFromAddr == null)
+            {
                 return false;
+            }
 
-            symbolName = symbolInfo.Name;
-            return true;
+            SYMBOL_INFO symbolInfo = new()
+            {
+                SizeOfStruct = SIZE_OF_SYMBOL_INFO,
+                MaxNameLen = MAX_SYM_NAME
+            };
+
+            if (SymFromAddr(CurrentProcess, address, out ulong displacement, ref symbolInfo))
+            {
+                if (displacement != 0)
+                    return false;
+
+                symbolName = symbolInfo.Name;
+                return true;
+            }
         }
 
         return false;
     }
 
-    /// <summary>
-    /// Finds the best available dbghelp.dll for current process architecture.
-    /// </summary>
-    /// <returns>
-    /// Full path to the preferred dbghelp.dll if found; otherwise null.
-    /// Preference order: Windows Kits Debuggers (by highest file version) for current arch,
-    /// then common Program Files Windows Kits locations, then the system copy.
-    /// </returns>
     internal static string FindDbgHelpDll()
     {
         try
         {
-            var arch = CUtils.GetProcessArchitectureName();
-            var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            string arch = CUtils.GetProcessArchitectureName();
+            HashSet<string> candidates = new(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var root in EnumerateWindowsKitsRoots())
+            foreach (string root in EnumerateWindowsKitsRoots())
             {
                 try
                 {
-                    var p = Path.Combine(root, CConsts.DebuggersString, arch, CConsts.DbgHelpDll);
-                    if (File.Exists(p)) candidates.Add(p);
+                    string p = Path.Combine(root, CConsts.DebuggersString, arch, CConsts.DbgHelpDll);
+                    if (File.Exists(p))
+                        candidates.Add(p);
                 }
                 catch
                 {
@@ -607,8 +797,8 @@ public static class CSymbolResolver
 
             try
             {
-                var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-                var pf86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+                string pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                string pf86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 
                 AddIfExists(candidates, CombineParts(pf86, CConsts.WindowsKitsString, "10", CConsts.DebuggersString, arch, CConsts.DbgHelpDll));
                 AddIfExists(candidates, CombineParts(pf, CConsts.WindowsKitsString, "10", CConsts.DebuggersString, arch, CConsts.DbgHelpDll));
@@ -622,8 +812,9 @@ public static class CSymbolResolver
 
             try
             {
-                var sys = Path.Combine(Environment.SystemDirectory, CConsts.DbgHelpDll);
-                if (File.Exists(sys)) candidates.Add(sys);
+                string sys = Path.Combine(Environment.SystemDirectory, CConsts.DbgHelpDll);
+                if (File.Exists(sys))
+                    candidates.Add(sys);
             }
             catch
             {
@@ -636,12 +827,12 @@ public static class CSymbolResolver
             string best = null;
             Version bestVer = null;
 
-            foreach (var c in candidates)
+            foreach (string c in candidates)
             {
                 try
                 {
-                    var fi = FileVersionInfo.GetVersionInfo(c);
-                    var ver = new Version(
+                    FileVersionInfo fi = FileVersionInfo.GetVersionInfo(c);
+                    Version ver = new(
                         SafePart(fi.FileMajorPart),
                         SafePart(fi.FileMinorPart),
                         SafePart(fi.FileBuildPart),
@@ -683,36 +874,31 @@ public static class CSymbolResolver
         static int SafePart(int v) => v < 0 ? 0 : v;
     }
 
-    /// <summary>
-    /// Enumerates installed Windows Kits root directories from HKLM for both 64-bit and 32-bit registry views.
-    /// </summary>
-    /// <returns>
-    /// A sequence of root paths (e.g., "C:\Program Files (x86)\Windows Kits\10\") suitable for composing Debuggers\<arch>\dbghelp.dll.
-    /// </returns>
     private static IEnumerable<string> EnumerateWindowsKitsRoots()
     {
-        var results = new List<string>();
+        List<string> results = [];
         string subKey = @"SOFTWARE\Microsoft\Windows Kits\Installed Roots";
-        string[] valueNames = new[] { "KitsRoot10", "KitsRoot81", "KitsRoot" };
+        string[] valueNames = ["KitsRoot10", "KitsRoot81", "KitsRoot"];
 
-        foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+        foreach (RegistryView view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
         {
             try
             {
                 using var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view);
                 using var key = baseKey.OpenSubKey(subKey);
-                if (key == null) continue;
+                if (key == null)
+                    continue;
 
-                foreach (var name in valueNames)
+                foreach (string name in valueNames)
                 {
-                    var v = key.GetValue(name) as string;
+                    string v = key.GetValue(name) as string;
                     if (!string.IsNullOrWhiteSpace(v))
                         results.Add(v);
                 }
             }
             catch
             {
-                // ignore and continue
+                // Intentionally silent.
             }
         }
 
@@ -721,34 +907,39 @@ public static class CSymbolResolver
 
     private static string CombineParts(params string[] parts)
     {
-        try { return Path.Combine(parts); } catch { return null; }
+        try
+        {
+            return Path.Combine(parts);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
-    /// <summary>
-    /// Determines whether the specified path points to the system-provided dbghelp.dll (System32 or SysWOW64).
-    /// </summary>
-    /// <param name="path">Path to test.</param>
-    /// <returns>True if the path resolves to the OS-shipped dbghelp.dll; otherwise false.</returns>
     private static bool IsSystemDbgHelp(string path)
     {
         try
         {
-            var sys32 = Path.Combine(Environment.SystemDirectory, CConsts.DbgHelpDll);
-            if (PathsEqual(path, sys32)) return true;
+            string sys32 = Path.Combine(Environment.SystemDirectory, CConsts.DbgHelpDll);
+            if (PathsEqual(path, sys32))
+                return true;
 
             try
             {
-                var sysX86 = Environment.GetFolderPath(Environment.SpecialFolder.SystemX86);
+                string sysX86 = Environment.GetFolderPath(Environment.SpecialFolder.SystemX86);
                 if (!string.IsNullOrEmpty(sysX86))
                 {
-                    var sysWow64 = Path.Combine(sysX86, CConsts.DbgHelpDll);
-                    if (PathsEqual(path, sysWow64)) return true;
+                    string sysWow64 = Path.Combine(sysX86, CConsts.DbgHelpDll);
+                    if (PathsEqual(path, sysWow64))
+                        return true;
                 }
             }
             catch
             {
                 // Intentionally silent.
             }
+
             return false;
         }
         catch
@@ -757,19 +948,16 @@ public static class CSymbolResolver
         }
     }
 
-    /// <summary>
-    /// Compares two file system paths for equality using full path normalization and case-insensitive comparison.
-    /// </summary>
-    /// <param name="a">First path.</param>
-    /// <param name="b">Second path.</param>
-    /// <returns>True if both paths refer to the same location; otherwise false.</returns>
     private static bool PathsEqual(string a, string b)
     {
         try
         {
-            if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return false;
-            var pa = Path.GetFullPath(a).TrimEnd('\\');
-            var pb = Path.GetFullPath(b).TrimEnd('\\');
+            if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b))
+                return false;
+
+            string pa = Path.GetFullPath(a).TrimEnd('\\');
+            string pb = Path.GetFullPath(b).TrimEnd('\\');
+
             return string.Equals(pa, pb, StringComparison.OrdinalIgnoreCase);
         }
         catch

--- a/src/WinDepends/Symbols/CSymbolResolver.cs
+++ b/src/WinDepends/Symbols/CSymbolResolver.cs
@@ -6,7 +6,7 @@
 *
 *  VERSION:     1.00
 *  
-*  DATE:        27 May 2026
+*  DATE:        28 May 2026
 *
 *  MS Symbols resolver support class.
 *
@@ -342,6 +342,22 @@ public sealed class CSymbolResolver : IDisposable
         return bResult;
     }
 
+    /// <summary>
+    /// Initializes the symbol resolver with the specified parameters.
+    /// </summary>
+    /// <param name="dllPath">The path to DbgHelp.dll.</param>
+    /// <param name="storePath">The path to store symbol files.</param>
+    /// <param name="useSymbols">Indicates whether to use symbols or only name undecoration.</param>
+    /// <returns>
+    /// A <see cref="SymbolResolverInitResult"/> value indicating the result of the initialization:
+    /// <list type="bullet">
+    ///   <item><description><see cref="SymbolResolverInitResult.DllLoadFailure"/> if DbgHelp.dll could not be loaded</description></item>
+    ///   <item><description><see cref="SymbolResolverInitResult.InitializationFailure"/> if initialization failed</description></item>
+    ///   <item><description><see cref="SymbolResolverInitResult.SuccessWithSymbolsAlternateDll"/> if successfully initialized with a better dbghelp.dll</description></item>
+    ///   <item><description><see cref="SymbolResolverInitResult.SuccessWithSymbols"/> if successfully initialized with symbols</description></item>
+    ///   <item><description><see cref="SymbolResolverInitResult.SuccessForUndecorationOnly"/> if successfully initialized for name undecoration only</description></item>
+    /// </list>
+    /// </returns>
     public SymbolResolverInitResult AllocateSymbolResolver(string dllPath, string storePath, bool useSymbols)
     {
         DllPath = dllPath;
@@ -444,6 +460,13 @@ public sealed class CSymbolResolver : IDisposable
         if (!SymbolsInitialized || string.IsNullOrEmpty(fileName))
             return;
 
+        if (!File.Exists(fileName))
+        {
+            RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Failed,
+                $"Symbol load failed for \"{fileName}\": file not found.");
+            return;
+        }
+
         lock (_dbgHelpLock)
         {
             loadedFileName = _nativeLoadedModuleFileName;
@@ -471,7 +494,7 @@ public sealed class CSymbolResolver : IDisposable
         }
 
         RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Queued,
-            $"Loading symbols for \"{fileName}\"...");
+            $"Loading symbols for \"{fileName}\", please wait...");
 
         _preloadSignal.Set();
     }
@@ -510,7 +533,7 @@ public sealed class CSymbolResolver : IDisposable
             try
             {
                 RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Loading,
-                    $"Loading symbols for \"{fileName}\"...");
+                    $"Loading symbols for \"{fileName}\", please wait...");
 
                 lock (_dbgHelpLock)
                 {
@@ -574,14 +597,21 @@ public sealed class CSymbolResolver : IDisposable
 
                 lock (_stateLock)
                 {
-                    if (requestId != _pendingRequestId)
+                    bool isCancelled;
+
+                    lock (_stateLock)
+                    {
+                        isCancelled = requestId != _pendingRequestId;
+                    }
+
+                    if (isCancelled)
                     {
                         RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Cancelled, string.Empty);
                         continue;
                     }
                 }
 
-                RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Loaded, string.Empty);
+                RaiseSymbolLoadStatusChanged(fileName, SymbolLoadState.Loaded, $"Symbols loading for \"{fileName}\" has been finished");
             }
             catch (Exception ex)
             {
@@ -673,6 +703,10 @@ public sealed class CSymbolResolver : IDisposable
         return result;
     }
 
+    /// <summary>
+    /// Releases all resources used by the symbol resolver.
+    /// </summary>
+    /// <returns>True if cleanup was successful, false otherwise.</returns>
     public bool ReleaseSymbolResolver()
     {
         bool bResult = false;
@@ -724,6 +758,11 @@ public sealed class CSymbolResolver : IDisposable
         ReleaseSymbolResolver();
     }
 
+    /// <summary>
+    /// Undecorates a C++ decorated function name.
+    /// </summary>
+    /// <param name="functionName">The decorated function name.</param>
+    /// <returns>The undecorated function name, or the original name if it wasn't decorated.</returns>
     internal string UndecorateFunctionName(string functionName)
     {
         lock (_dbgHelpLock)
@@ -735,6 +774,7 @@ public sealed class CSymbolResolver : IDisposable
 
             StringBuilder sb = new(1024);
 
+            // Note: DependencyWalker uses UNDNAME.NoAllocateLanguage | UNDNAME.NoMsKeyWords | UNDNAME.NoFunctionReturns | UNDNAME.NoAccessSpecifiers
             if (UnDecorateSymbolName(functionName, sb, sb.Capacity, UNDNAME.NoMsKeyWords) > 0)
             {
                 return sb.ToString();
@@ -744,6 +784,12 @@ public sealed class CSymbolResolver : IDisposable
         return functionName;
     }
 
+    /// <summary>
+    /// Queries for a symbol at the specified address.
+    /// </summary>
+    /// <param name="address">The address to query.</param>
+    /// <param name="symbolName">When this method returns, contains the symbol name if found, or null if not found.</param>
+    /// <returns>True if a symbol was found at the specified address, false otherwise.</returns>
     public bool QuerySymbolForAddress(UInt64 address, out string symbolName)
     {
         symbolName = null;
@@ -774,6 +820,14 @@ public sealed class CSymbolResolver : IDisposable
         return false;
     }
 
+    /// <summary>
+    /// Finds the best available dbghelp.dll for current process architecture.
+    /// </summary>
+    /// <returns>
+    /// Full path to the preferred dbghelp.dll if found; otherwise null.
+    /// Preference order: Windows Kits Debuggers (by highest file version) for current arch,
+    /// then common Program Files Windows Kits locations, then the system copy.
+    /// </returns>
     internal static string FindDbgHelpDll()
     {
         try
@@ -874,6 +928,12 @@ public sealed class CSymbolResolver : IDisposable
         static int SafePart(int v) => v < 0 ? 0 : v;
     }
 
+    /// <summary>
+    /// Enumerates installed Windows Kits root directories from HKLM for both 64-bit and 32-bit registry views.
+    /// </summary>
+    /// <returns>
+    /// A sequence of root paths (e.g., "C:\Program Files (x86)\Windows Kits\10\") suitable for composing Debuggers\<arch>\dbghelp.dll.
+    /// </returns>
     private static IEnumerable<string> EnumerateWindowsKitsRoots()
     {
         List<string> results = [];
@@ -917,6 +977,11 @@ public sealed class CSymbolResolver : IDisposable
         }
     }
 
+    /// <summary>
+    /// Determines whether the specified path points to the system-provided dbghelp.dll (System32 or SysWOW64).
+    /// </summary>
+    /// <param name="path">Path to test.</param>
+    /// <returns>True if the path resolves to the OS-shipped dbghelp.dll; otherwise false.</returns>
     private static bool IsSystemDbgHelp(string path)
     {
         try


### PR DESCRIPTION
Convert CSymbolResolver from a static helper into a disposable, instance-based class with thread-safe state and an asynchronous preload worker.