### PR TITLE
Add optional STL template-name simplification for undecorated C++ names

### DIFF
--- a/src/WinDepends/CConsts.cs
+++ b/src/WinDepends/CConsts.cs
@@ -58,6 +58,7 @@ public static class CConsts
     public const int TagResolveAPIsets = 123;
     public const int TagUpperCaseModuleNames = 124;
     public const int TagClearLogOnFileOpen = 125;
+    public const int TagSimplifyStlNames = 126;
     public const int TagViewExternalViewer = 200;
     public const int TagViewProperties = 201;
     public const int TagSystemInformation = 300;

--- a/src/WinDepends/Configuration/CConfigMgr.cs
+++ b/src/WinDepends/Configuration/CConfigMgr.cs
@@ -42,6 +42,8 @@ public class CConfiguration
     [DataMember]
     public bool ViewUndecorated { get; set; }
     [DataMember]
+    public bool SimplifyStlNames { get; set; }
+    [DataMember]
     public bool ResolveAPIsets { get; set; }
     [DataMember]
     public bool FullPaths { get; set; }
@@ -163,6 +165,7 @@ public class CConfiguration
         SortColumnModules = other.SortColumnModules;
         ModuleNodeDepthMax = other.ModuleNodeDepthMax;
         ViewUndecorated = other.ViewUndecorated;
+        SimplifyStlNames = other.SimplifyStlNames;
         ResolveAPIsets = other.ResolveAPIsets;
         FullPaths = other.FullPaths;
         AutoExpands = other.AutoExpands;

--- a/src/WinDepends/Forms/ConfigurationForm.Designer.cs
+++ b/src/WinDepends/Forms/ConfigurationForm.Designer.cs
@@ -59,6 +59,7 @@
             chBoxUpperCase = new CheckBox();
             chBoxResolveApiSets = new CheckBox();
             chBoxUndecorateSymbols = new CheckBox();
+            chBoxSimplifyStlNames = new CheckBox();
             chBoxAutoExpands = new CheckBox();
             groupBox2 = new GroupBox();
             chBoxUseESCKey = new CheckBox();
@@ -366,6 +367,7 @@
             groupBox3.Controls.Add(chBoxUpperCase);
             groupBox3.Controls.Add(chBoxResolveApiSets);
             groupBox3.Controls.Add(chBoxUndecorateSymbols);
+            groupBox3.Controls.Add(chBoxSimplifyStlNames);
             groupBox3.Controls.Add(chBoxAutoExpands);
             groupBox3.Location = new Point(6, 71);
             groupBox3.Name = "groupBox3";
@@ -489,7 +491,19 @@
             chBoxUndecorateSymbols.Text = "Undecorate C++ Functions";
             chBoxUndecorateSymbols.UseVisualStyleBackColor = true;
             chBoxUndecorateSymbols.Click += ChBox_Click;
-            // 
+            //
+            // chBoxSimplifyStlNames
+            //
+            chBoxSimplifyStlNames.AutoSize = true;
+            chBoxSimplifyStlNames.Location = new Point(250, 83);
+            chBoxSimplifyStlNames.Name = "chBoxSimplifyStlNames";
+            chBoxSimplifyStlNames.Size = new Size(200, 19);
+            chBoxSimplifyStlNames.TabIndex = 19;
+            chBoxSimplifyStlNames.Tag = "126";
+            chBoxSimplifyStlNames.Text = "Simplify STL Template Names";
+            chBoxSimplifyStlNames.UseVisualStyleBackColor = true;
+            chBoxSimplifyStlNames.Click += ChBox_Click;
+            //
             // chBoxAutoExpands
             // 
             chBoxAutoExpands.AutoSize = true;
@@ -1681,6 +1695,7 @@
         private GroupBox groupBox3;
         private CheckBox chBoxResolveApiSets;
         private CheckBox chBoxUndecorateSymbols;
+        private CheckBox chBoxSimplifyStlNames;
         private CheckBox chBoxAutoExpands;
         private CheckBox chBoxFullPaths;
         private TabPage tabExternalViewer;

--- a/src/WinDepends/Forms/ConfigurationForm.cs
+++ b/src/WinDepends/Forms/ConfigurationForm.cs
@@ -337,6 +337,7 @@ public partial class ConfigurationForm : Form
         chBoxAutoExpands.Checked = _config.AutoExpands;
         chBoxFullPaths.Checked = _config.FullPaths;
         chBoxUndecorateSymbols.Checked = _config.ViewUndecorated;
+        chBoxSimplifyStlNames.Checked = _config.SimplifyStlNames;
         chBoxResolveApiSets.Checked = _config.ResolveAPIsets;
         chBoxHighlightApiSet.Checked = _config.HighlightApiSet;
         chBoxApiSetNamespace.Checked = _config.UseApiSetSchemaFile;
@@ -504,6 +505,10 @@ public partial class ConfigurationForm : Form
 
             case CConsts.TagViewUndecorated:
                 _config.ViewUndecorated = isChecked;
+                break;
+
+            case CConsts.TagSimplifyStlNames:
+                _config.SimplifyStlNames = isChecked;
                 break;
 
             case CConsts.TagResolveAPIsets:

--- a/src/WinDepends/MainForm/MainForm.cs
+++ b/src/WinDepends/MainForm/MainForm.cs
@@ -198,6 +198,7 @@ public partial class MainForm : Form
             _configuration.SymbolsStorePath = _symbolResolver.StorePath;
         }
 
+        _symbolResolver.SimplifyTemplateDefaults = _configuration.SimplifyStlNames;
         _symbolResolver.SymbolLoadStatusChanged += SymbolResolver_SymbolLoadStatusChanged;
 
         //
@@ -793,6 +794,7 @@ public partial class MainForm : Form
         var bFullPathPrev = _configuration.FullPaths;
         var bUpperCaseModulesNamesPrev = _configuration.UpperCaseModuleNames;
         var bUndecoratedPrev = _configuration.ViewUndecorated;
+        var bSimplifyStlPrev = _configuration.SimplifyStlNames;
         var bResolveAPISetsPrev = _configuration.ResolveAPIsets;
         var bHighlightAPISetsPrev = _configuration.HighlightApiSet;
         var bUseApiSetSchemaFilePrev = _configuration.UseApiSetSchemaFile;
@@ -837,7 +839,18 @@ public partial class MainForm : Form
                     UpdateFileView(FileViewUpdateAction.ModulesTreeAndListChange);
                 }
 
-                if (_configuration.ViewUndecorated != bUndecoratedPrev)
+                if (_configuration.SimplifyStlNames != bSimplifyStlPrev)
+                {
+                    //
+                    // The simplified spelling is baked into the cached undecorated
+                    // name, so drop the cache to force re-decoration on next view.
+                    //
+                    _symbolResolver.SimplifyTemplateDefaults = _configuration.SimplifyStlNames;
+                    ClearUndecoratedNameCache();
+                }
+
+                if (_configuration.ViewUndecorated != bUndecoratedPrev ||
+                    _configuration.SimplifyStlNames != bSimplifyStlPrev)
                 {
                     UpdateFileView(FileViewUpdateAction.FunctionsUndecorateChange);
                 }
@@ -1488,6 +1501,32 @@ public partial class MainForm : Form
     private void MenuExitItem_Click(object sender, EventArgs e)
     {
         Close();
+    }
+
+    /// <summary>
+    /// Clears cached undecorated names across all loaded modules so they are
+    /// recomputed with the current decoration / STL-simplification settings.
+    /// </summary>
+    private void ClearUndecoratedNameCache()
+    {
+        foreach (CModule module in _loadedModulesList)
+        {
+            if (module.ModuleData?.Exports is { } exports)
+            {
+                foreach (CFunction function in exports)
+                {
+                    function.UndecoratedName = string.Empty;
+                }
+            }
+
+            if (module.ParentImports is { } imports)
+            {
+                foreach (CFunction function in imports)
+                {
+                    function.UndecoratedName = string.Empty;
+                }
+            }
+        }
     }
 
     private void CopyFunctionNamesToClipboard(ListView listView, List<CFunction> functions)

--- a/src/WinDepends/Symbols/CStlNameSimplifier.cs
+++ b/src/WinDepends/Symbols/CStlNameSimplifier.cs
@@ -1,0 +1,376 @@
+﻿/*******************************************************************************
+*
+*  (C) COPYRIGHT AUTHORS, 2024 - 2026
+*
+*  TITLE:       CSTLNAMESIMPLIFIER.CS
+*
+*  VERSION:     1.00
+*
+*  DATE:        03 Jun 2026
+*
+*  Collapses the canonical (default-argument) forms produced by the MSVC
+*  demangler into their conventional STL spellings, e.g.
+*
+*    std::basic_string<char,std::char_traits<char>,std::allocator<char> >
+*       -> std::string
+*    std::map<int,T,std::less<int>,std::allocator<std::pair<int const ,T> > >
+*       -> std::map<int,T>
+*    std::vector<T,std::allocator<T> >
+*       -> std::vector<T>
+*
+*  Only the default-value template forms of the standard library are matched;
+*  user templates and non-default arguments are left untouched. The transform
+*  is bracket-aware (it walks balanced angle brackets) because regular
+*  expressions cannot reliably split nested template argument lists.
+*
+* THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
+* ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED
+* TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+* PARTICULAR PURPOSE.
+*
+*******************************************************************************/
+using System.Text;
+
+namespace WinDepends;
+
+/// <summary>
+/// Folds MSVC default template-argument forms of the C++ standard library into
+/// their conventional typedef spellings. Intended purely for display.
+/// </summary>
+internal static class CStlNameSimplifier
+{
+    /// <summary>
+    /// Returns <paramref name="name"/> with recognized STL default-argument
+    /// template forms collapsed. On any unexpected input the original string is
+    /// returned unchanged so the feature can never corrupt a displayed name.
+    /// </summary>
+    public static string Simplify(string name)
+    {
+        if (string.IsNullOrEmpty(name) || name.IndexOf('<') < 0)
+        {
+            return name;
+        }
+
+        try
+        {
+            return Transform(name);
+        }
+        catch
+        {
+            return name;
+        }
+    }
+
+    /// <summary>
+    /// Recursively rewrites every template-id found in <paramref name="s"/>.
+    /// Inner argument lists are transformed before the enclosing template is
+    /// folded, so nested defaults collapse bottom-up.
+    /// </summary>
+    private static string Transform(string s)
+    {
+        var sb = new StringBuilder(s.Length);
+        int i = 0;
+
+        while (i < s.Length)
+        {
+            char c = s[i];
+
+            if (c == '<')
+            {
+                string ident = PeekLastIdentifier(sb);
+
+                // Skip operator<, operator<<, lambdas (<lambda_..>) and anything
+                // not preceded by a real identifier - treat '<' literally.
+                if (ident.Length == 0 || ident.EndsWith("operator", StringComparison.Ordinal))
+                {
+                    sb.Append(c);
+                    i++;
+                    continue;
+                }
+
+                int end = FindMatchingAngle(s, i);
+                if (end < 0)
+                {
+                    sb.Append(c);
+                    i++;
+                    continue;
+                }
+
+                string inner = s.Substring(i + 1, end - i - 1);
+                List<string> args = SplitTopLevel(Transform(inner));
+
+                sb.Length -= ident.Length;          // remove identifier, re-emit folded
+                sb.Append(Fold(ident, args));
+                i = end + 1;
+            }
+            else
+            {
+                sb.Append(c);
+                i++;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Applies the STL folding rules for a single template-id whose argument
+    /// list has already been simplified. Unrecognized templates are rebuilt
+    /// verbatim.
+    /// </summary>
+    private static string Fold(string ident, List<string> args)
+    {
+        switch (ident)
+        {
+            case "std::basic_string":
+                // <CharT, char_traits<CharT>, allocator<CharT>>
+                if (args.Count == 3 &&
+                    IsSpecializationOf(args[1], "std::char_traits") &&
+                    IsSpecializationOf(args[2], "std::allocator"))
+                {
+                    string alias = StringAlias(args[0], isView: false);
+                    if (alias != null) return alias;
+                }
+                break;
+
+            case "std::basic_string_view":
+                // <CharT, char_traits<CharT>>
+                if (args.Count == 2 &&
+                    IsSpecializationOf(args[1], "std::char_traits"))
+                {
+                    string alias = StringAlias(args[0], isView: true);
+                    if (alias != null) return alias;
+                }
+                break;
+
+            case "std::vector":
+            case "std::deque":
+            case "std::list":
+            case "std::forward_list":
+                // <T, allocator<T>>
+                if (args.Count == 2 && IsSpecializationOf(args[1], "std::allocator"))
+                {
+                    return Rebuild(ident, args[0]);
+                }
+                break;
+
+            case "std::set":
+            case "std::multiset":
+                // <Key, less<Key>, allocator<Key>>
+                if (args.Count == 3 &&
+                    IsSpecializationOf(args[1], "std::less") &&
+                    IsSpecializationOf(args[2], "std::allocator"))
+                {
+                    return Rebuild(ident, args[0]);
+                }
+                break;
+
+            case "std::map":
+            case "std::multimap":
+                // <Key, T, less<Key>, allocator<pair<const Key, T>>>
+                if (args.Count == 4 &&
+                    IsSpecializationOf(args[2], "std::less") &&
+                    IsSpecializationOf(args[3], "std::allocator"))
+                {
+                    return Rebuild(ident, args[0], args[1]);
+                }
+                break;
+
+            case "std::unordered_set":
+            case "std::unordered_multiset":
+                // <Key, hash<Key>, equal_to<Key>, allocator<Key>>
+                if (args.Count == 4 &&
+                    IsSpecializationOf(args[1], "std::hash") &&
+                    IsSpecializationOf(args[2], "std::equal_to") &&
+                    IsSpecializationOf(args[3], "std::allocator"))
+                {
+                    return Rebuild(ident, args[0]);
+                }
+                break;
+
+            case "std::unordered_map":
+            case "std::unordered_multimap":
+                // <Key, T, hash<Key>, equal_to<Key>, allocator<pair<const Key, T>>>
+                if (args.Count == 5 &&
+                    IsSpecializationOf(args[2], "std::hash") &&
+                    IsSpecializationOf(args[3], "std::equal_to") &&
+                    IsSpecializationOf(args[4], "std::allocator"))
+                {
+                    return Rebuild(ident, args[0], args[1]);
+                }
+                break;
+
+            case "std::unique_ptr":
+                // <T, default_delete<T>>
+                if (args.Count == 2 && IsSpecializationOf(args[1], "std::default_delete"))
+                {
+                    return Rebuild(ident, args[0]);
+                }
+                break;
+        }
+
+        return Rebuild(ident, args);
+    }
+
+    /// <summary>
+    /// Maps a character element type to the std::string / std::string_view family
+    /// alias, or null when the element type is not a known character type.
+    /// </summary>
+    private static string StringAlias(string element, bool isView)
+    {
+        switch (StripLeadingKeywords(element).Trim())
+        {
+            case "char": return isView ? "std::string_view" : "std::string";
+            case "wchar_t": return isView ? "std::wstring_view" : "std::wstring";
+            case "char8_t": return isView ? "std::u8string_view" : "std::u8string";
+            case "char16_t": return isView ? "std::u16string_view" : "std::u16string";
+            case "char32_t": return isView ? "std::u32string_view" : "std::u32string";
+            default: return null;
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="arg"/> is a specialization of
+    /// <paramref name="template"/> (e.g. "std::allocator&lt;...&gt;").
+    /// </summary>
+    private static bool IsSpecializationOf(string arg, string template)
+    {
+        arg = StripLeadingKeywords(arg).TrimStart();
+        return arg.StartsWith(template, StringComparison.Ordinal) &&
+               arg.Length > template.Length &&
+               arg[template.Length] == '<';
+    }
+
+    private static string Rebuild(string ident, params string[] args)
+        => Rebuild(ident, (IReadOnlyList<string>)args);
+
+    /// <summary>
+    /// Reconstructs "ident&lt;args&gt;" keeping the demangler convention of a
+    /// space before a closing angle bracket that follows another '&gt;'.
+    /// </summary>
+    private static string Rebuild(string ident, IReadOnlyList<string> args)
+    {
+        if (args.Count == 0)
+        {
+            return ident;
+        }
+
+        var sb = new StringBuilder(ident.Length + 16);
+        sb.Append(ident).Append('<');
+
+        for (int i = 0; i < args.Count; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(args[i]);
+        }
+
+        if (args[args.Count - 1].EndsWith(">", StringComparison.Ordinal))
+        {
+            sb.Append(' ');
+        }
+        sb.Append('>');
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Splits a template argument list on top-level commas, ignoring commas
+    /// nested inside angle brackets, parentheses or square brackets.
+    /// </summary>
+    private static List<string> SplitTopLevel(string s)
+    {
+        var result = new List<string>();
+        int depth = 0, start = 0;
+
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            switch (c)
+            {
+                case '<':
+                case '(':
+                case '[':
+                    depth++;
+                    break;
+                case '>':
+                case ')':
+                case ']':
+                    if (depth > 0) depth--;
+                    break;
+                case ',':
+                    if (depth == 0)
+                    {
+                        result.Add(s.Substring(start, i - start).Trim());
+                        start = i + 1;
+                    }
+                    break;
+            }
+        }
+
+        result.Add(s.Substring(start).Trim());
+        return result;
+    }
+
+    /// <summary>
+    /// Returns the index of the '&gt;' that matches the '&lt;' at
+    /// <paramref name="open"/>, or -1 when the brackets are unbalanced.
+    /// </summary>
+    private static int FindMatchingAngle(string s, int open)
+    {
+        int depth = 0;
+        for (int i = open; i < s.Length; i++)
+        {
+            if (s[i] == '<') depth++;
+            else if (s[i] == '>')
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Returns the identifier characters immediately preceding the current end
+    /// of <paramref name="sb"/> without modifying it.
+    /// </summary>
+    private static string PeekLastIdentifier(StringBuilder sb)
+    {
+        int end = sb.Length;
+        int i = end - 1;
+        while (i >= 0 && IsIdentifierChar(sb[i]))
+        {
+            i--;
+        }
+        return sb.ToString(i + 1, end - (i + 1));
+    }
+
+    private static bool IsIdentifierChar(char c)
+        => char.IsLetterOrDigit(c) || c == '_' || c == ':';
+
+    /// <summary>
+    /// Strips MSVC type keywords ("class ", "struct ", "enum ", "union ") that
+    /// may prefix a type when the demangler is not run with NoMsKeyWords.
+    /// </summary>
+    private static string StripLeadingKeywords(string s)
+    {
+        s = s.TrimStart();
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (string kw in s_typeKeywords)
+            {
+                if (s.StartsWith(kw, StringComparison.Ordinal))
+                {
+                    s = s.Substring(kw.Length).TrimStart();
+                    changed = true;
+                }
+            }
+        }
+        return s;
+    }
+
+    private static readonly string[] s_typeKeywords =
+        ["class ", "struct ", "enum ", "union "];
+}

--- a/src/WinDepends/Symbols/CSymbolResolver.cs
+++ b/src/WinDepends/Symbols/CSymbolResolver.cs
@@ -232,6 +232,12 @@ public sealed class CSymbolResolver : IDisposable
 
     public bool SymbolsInitialized { get; private set; }
     public bool UndecorationReady { get; private set; }
+
+    /// <summary>
+    /// When set, recognized STL default-argument template forms in undecorated
+    /// names are collapsed to their conventional spellings (e.g. std::string).
+    /// </summary>
+    public bool SimplifyTemplateDefaults { get; set; }
     public string DllPath { get; private set; }
     public string StorePath { get; private set; }
 
@@ -777,7 +783,10 @@ public sealed class CSymbolResolver : IDisposable
             // Note: DependencyWalker uses UNDNAME.NoAllocateLanguage | UNDNAME.NoMsKeyWords | UNDNAME.NoFunctionReturns | UNDNAME.NoAccessSpecifiers
             if (UnDecorateSymbolName(functionName, sb, sb.Capacity, UNDNAME.NoMsKeyWords) > 0)
             {
-                return sb.ToString();
+                string undecorated = sb.ToString();
+                return SimplifyTemplateDefaults
+                    ? CStlNameSimplifier.Simplify(undecorated)
+                    : undecorated;
             }
         }
 


### PR DESCRIPTION
## Summary

Adds an optional, display-only simplification of undecorated C++ names that
collapses the canonical default-argument forms emitted by the MSVC demangler
into their conventional STL spellings, e.g.

| Demangled | Simplified |
|---|---|
| `std::basic_string<char,std::char_traits<char>,std::allocator<char> >` | `std::string` |
| `std::basic_string_view<char,std::char_traits<char> >` | `std::string_view` |
| `std::vector<T,std::allocator<T> >` | `std::vector<T>` |
| `std::map<K,V,std::less<K>,std::allocator<std::pair<const K,V> > >` | `std::map<K,V>` |
| `std::unordered_map<K,V,std::hash<K>,std::equal_to<K>,std::allocator<...> >` | `std::unordered_map<K,V>` |

This makes long, allocator-/comparator-heavy template names far easier to read
in the imports/exports lists — the common request that motivated `stl-filt`.

## Scope and design

- **Only the default-value template forms** of the standard library are matched:
  `basic_string`/`basic_string_view`, `vector`/`list`/`deque`/`forward_list`,
  `set`/`multiset`, `map`/`multimap`, `unordered_*`, and `unique_ptr`.
  User templates and non-default arguments are left untouched.
- The transform is **bracket-aware** (walks balanced angle brackets and folds
  bottom-up) rather than regex-based, because nested template argument lists
  (`std::map<int,std::vector<std::string> >`, allocators wrapping `std::pair`
  with commas) cannot be split reliably with regular expressions.
- `operator<` / `operator<<`, lambda names, and unbalanced input are guarded;
  any unexpected input is returned unchanged so a displayed name can never be
  corrupted.

## UX

New **"Simplify STL Template Names"** checkbox on *Configuration → Appearance*
(off by default). Toggling it clears the cached undecorated names and refreshes
the view. It composes with the existing "Undecorate C++ Functions" option.

## Implementation

- `Symbols/CStlNameSimplifier.cs` — the standalone, WinForms-free transformer.
- `CSymbolResolver.SimplifyTemplateDefaults` applies it at the end of
  `UndecorateFunctionName`.
- `CConfiguration.SimplifyStlNames` (persisted, default false), wired through
  `MainForm` and the configuration form.

## Tests

A decoupled xUnit project (`WinDepends.StlSimplifier.Tests`) links only the
simplifier source — no WinForms / windows-specific TFM — and covers folding,
bottom-up nesting, the function-signature case, `operator</<<` guards, user
templates, and malformed-input fallbacks. 23/23 passing.

## Incidental

The repository had no `.gitignore`; one for .NET/C++ build artifacts is included
as a separate commit. Happy to drop it from this PR if you'd prefer it separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)